### PR TITLE
Force responses v0.3.0 to fix tests with python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests
 requests_oauthlib
 
 pytest
-responses
+responses==0.3.0


### PR DESCRIPTION
The `responses` package was updated a week ago, which broke tests for python 2.7. This forces us to use an older version which makes our tests pass on travis.