### PR TITLE
Fix broken unittests in Python 2.7.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,11 +1,10 @@
+import json
+import unittest
 
 import asana
 import requests
 import responses
-import unittest
-import json
-
-from six import next
+from six import add_metaclass, next
 from responses import GET, PUT, POST, DELETE
 
 # Define JSON primitives so we can just copy in JSON:
@@ -13,25 +12,31 @@ false = False
 true = True
 null = None
 
-# From https://github.com/dropbox/responses/issues/31#issuecomment-63165210
-from inspect import getmembers, isfunction, ismethod
-def decallmethods(decorator, prefix='test_'):
-    def dectheclass(cls):
-        for name, m in getmembers(cls, predicate=lambda x: isfunction(x) or ismethod(x)):
-            if name.startswith(prefix):
-                setattr(cls, name, decorator(m))
-        return cls
-    return dectheclass
 
-# TestCase subclass that automatically decorates test methods with responses.activate and sets up a client instance
+def create_decorating_metaclass(decorators, prefix='test_'):
+    class DecoratingMethodsMetaclass(type):
+        def __new__(cls, name, bases, namespace):
+            namespace_items = tuple(namespace.items())
+            for key, val in namespace_items:
+                if key.startswith(prefix) and callable(val):
+                    for dec in decorators:
+                        val = dec(val)
+                    namespace[key] = val
+            return type.__new__(cls, name, bases, dict(namespace))
+
+    return DecoratingMethodsMetaclass
+
+
+# TestCase subclass that automatically decorates test methods with
+# responses.activate and sets up a client instance
+@add_metaclass(create_decorating_metaclass((responses.activate,)))
 class ClientTestCase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        decallmethods(responses.activate)(cls)
 
     def setUp(self):
         self.client = asana.Client(
             base_url='http://app',
-            poll_interval=0, # no delay when polling to speed up tests
-            iterator_type=None, # disable iterator and limit to match existing tests for now
+            # no delay when polling to speed up tests
+            poll_interval=0,
+            # disable iterator and limit to match existing tests for now
+            iterator_type=None,
         )


### PR DESCRIPTION
Originally all test classes were decorated by going over the class via
inspection - however, this doesn't work in Python 2.7 because the
methods that are returned from getmembers are all unbound (in Python 3+,
this is fixed as all methods are just function objects).

Now this uses a metaclass with six to work in both Python 2 and 3.