### PR TITLE
Add pypi classifiers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest~=2.8.7
 requests_oauthlib~=0.6.1
 requests~=2.9.1
 responses~=0.5.1
+six~=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -4,24 +4,38 @@ import sys
 import os
 from setuptools import setup, find_packages
 
+from version import VERSION
+
 assert sys.version_info >= (2, 6), 'We only support Python 2.6+'
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'asana'))
-from version import VERSION
 
-setup(name='asana',
-      version=VERSION,
-      description='Asana API client',
-      # license='',
-      install_requires=[
-          'requests~=2.9.1',
-          'requests_oauthlib~=0.6.1',
-          'six~=1.10.0'
-      ],
-      author='Asana, Inc',
-      # author_email='',
-      url='http://github.com/asana/python-asana',
-      packages = find_packages(),
-      keywords= 'asana',
-      zip_safe = True,
-      test_suite='tests')
+setup(
+    name='asana',
+    version=VERSION,
+    description='Asana API client',
+    license='MIT',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4'
+    ],
+    install_requires=[
+        'requests~=2.9.1',
+        'requests_oauthlib~=0.6.1',
+        'six~=1.10.0'
+    ],
+    author='Asana, Inc',
+    # author_email='',
+    url='http://github.com/asana/python-asana',
+    packages=find_packages(exclude=('tests',)),
+    keywords='asana',
+    zip_safe=True,
+    test_suite='tests')


### PR DESCRIPTION
Fixes #35.

- Adds missing six package to dev requirements file (I believe requests has it as a dependency so this has never broken someone's local setup, but we should be explicit on packages that are necessary in case this were to change).
- Adds several classifiers including Python versions 2.6, 2.7, 3.3, 3.4 (didn't add for 3.5 as we're not testing this in Travis CI yet). Generally looked at other python projects to make sure this looked like a reasonable list.
- Excluded the tests package for distribution - I don't think it's necessary for people to use the library, and they can always clone the repo if they're doing development. However, happy to modify and keep it in the distribution as well. Was generally following the advice here: https://packaging.python.org/en/latest/distributing/#packages