### PR TITLE
Revert deploy script (it doesn't distribute with the Python egg)

### DIFF
--- a/asana/__init__.py
+++ b/asana/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'asana'
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2016 Asana, Inc.'
 

--- a/deploy.py
+++ b/deploy.py
@@ -7,40 +7,27 @@ Script for deploying a new version of the python-asana library.
 import argparse
 import re
 import subprocess
-
-VERSION_REGEX = r'^(__version__\s*=\s*[\'"])([^\'"]*)([\'"])'
-INIT_FILE = 'asana/__init__.py'
-
-
-def deploy():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        'version',
-        help='Version to deploy as, in format x.y.z')
-    args = parser.parse_args()
-
-    if not re.match('[0-9]+[.][0-9]+[.][0-9]+', args.version):
-        argparse.error('Invalid version: {0}'.format(args.version))
-
-    with open(INIT_FILE) as init_file:
-        init_file_contents = init_file.read()
-
-    repl = r'\g<1>{0}\g<3>'.format(args.version)
-    new_file_contents = re.sub(
-        VERSION_REGEX, repl, init_file_contents, flags=re.MULTILINE)
-
-    with open(INIT_FILE, 'w') as init_file:
-        init_file.write(new_file_contents)
-
-    subprocess.call(
-        'git commit -m "Releasing version %s" asana/version.py' % args.version,
-        shell=True)
-    subprocess.call(
-        'git tag %s' % args.version, shell=True)
-    subprocess.call(
-        'git push --tags origin master:master', shell=True)
-    print 'Successfully deployed version %s' % args.version
-
+import sys
 
 if __name__ == '__main__':
-    deploy()
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    'version',
+    help='Version to deploy as, in format x.y.z')
+  args = parser.parse_args()
+
+  if not re.match('[0-9]+[.][0-9]+[.][0-9]+', args.version):
+    print 'Invalid version: %s' % args.version
+    sys.exit(1)
+
+  version_file = open('asana/version.py', 'w')
+  version_file.write("VERSION = '%s'\n" % args.version)
+  version_file.close()
+
+  subprocess.call(
+    'git commit -m "Releasing version %s" asana/version.py' % args.version, shell=True)
+  subprocess.call(
+    'git tag %s' % args.version, shell=True)
+  subprocess.call(
+    'git push --tags origin master:master', shell=True)
+  print 'Successfully deployed version %s' % args.version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 import os
 from setuptools import setup, find_packages
 
-from version import VERSION
+from asana import __version__
 
 assert sys.version_info >= (2, 6), 'We only support Python 2.6+'
 
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'asana'))
 
 setup(
     name='asana',
-    version=VERSION,
+    version=__version__,
     description='Asana API client',
     license='MIT',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,18 @@
 #!/usr/bin/env python
 
-import os
-import re
 import sys
+import os
 from setuptools import setup, find_packages
 
-from deploy import INIT_FILE, VERSION_REGEX
+from version import VERSION
 
 assert sys.version_info >= (2, 6), 'We only support Python 2.6+'
-
-with open(INIT_FILE) as fobj:
-    version = re.search(VERSION_REGEX, fobj.read(), re.MULTILINE).group(2)
-
-if not version:
-    raise RuntimeError('Cannot find __version__ in {0}'.format(INIT_FILE))
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'asana'))
 
 setup(
     name='asana',
-    version=version,
+    version=VERSION,
     description='Asana API client',
     license='MIT',
     classifiers=[


### PR DESCRIPTION
With the latest version of the library, it was required to resolve the version in setup.py