### PR TITLE
Fix attempt: version specifier ~= is not supported on older installat…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ setup(
         'Programming Language :: Python :: 3.4'
     ],
     install_requires=[
-        'requests~=2.9.1',
-        'requests_oauthlib~=0.6.1',
-        'six~=1.10.0'
+        'requests >=2.9.1, == 2.9.*',
+        'requests_oauthlib >= 0.6.1, == 0.6.*',
+        'six >= 1.10.0, == 1.10.*'
     ],
     author='Asana, Inc',
     # author_email='',


### PR DESCRIPTION
…ions of pip

(this is really tough to test, but we were running into this issue in our sandbox / older machines, so this is an attempt to make a backwards-compatible equivalent to what ~= does).