### PR TITLE
Add timeout to request library options.

### DIFF
--- a/asana/client.py
+++ b/asana/client.py
@@ -46,7 +46,8 @@ class Client:
 
     CLIENT_OPTIONS = set(DEFAULTS.keys())
     QUERY_OPTIONS = set(['limit', 'offset', 'sync'])
-    REQUEST_OPTIONS = set(['headers', 'params', 'data', 'files', 'verify'])
+    REQUEST_OPTIONS = set(
+        ['headers', 'params', 'data', 'files', 'verify', 'timeout'])
     API_OPTIONS = set(['pretty', 'fields', 'expand'])
 
     ALL_OPTIONS = CLIENT_OPTIONS | QUERY_OPTIONS | REQUEST_OPTIONS | API_OPTIONS


### PR DESCRIPTION
Currently you can't set a timeout on a request, leading to program hangs when the connection never gets back to you (I've ran into this personally a few times).

This adds the ability to set the timeout on any call, as recommended by requests:
http://docs.python-requests.org/en/master/user/quickstart/#timeouts

Would *really* love to be able to use this sometime soon.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182692189208479/280851287363701)
