### PR TITLE
Make package requirements less stringent.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pytest~=2.8.7
-requests_oauthlib~=0.6.1
-requests~=2.14.2
-responses~=0.5.1
-six~=1.10.0
+pytest~=2.8
+requests_oauthlib~=0.8.0
+requests~=2.14
+responses~=0.8.1
+six~=1.10

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ setup(
         'Programming Language :: Python :: 3.4'
     ],
     install_requires=[
-        'requests >=2.14.2, == 2.14.*',
-        'requests_oauthlib >= 0.6.1, == 0.6.*',
-        'six >= 1.10.0, == 1.10.*'
+        'requests >= 2.14, == 2.*',
+        'requests_oauthlib >= 0.8.0, == 0.8.*',
+        'six >= 1.10, == 1.*'
     ],
     author='Asana, Inc',
     # author_email='',


### PR DESCRIPTION
* Upgrade most packages to recent versions (tested).
* Set compatibility for > 1.0 releases at minor releases (second digit).
* Set compatibility for < 1.0 releases at micro releases (third digit).

Tested via unit tests, also ran a local installation to make sure the syntax worked for setup.py (in addition to requirements.txt).
  