### PR TITLE
Allow requests-oauthlib v1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest~=2.8
-requests_oauthlib~=0.8.0
+requests_oauthlib>=0.8.0<1.1
 requests~=2.14
 responses~=0.8.1
 six~=1.10


### PR DESCRIPTION
Other packages I use require requests-oauthlib v1.0.0, and it is compatible with python-asana (indirectly measured through the django-asana test suite since there are no tests here; and directly measured in my production environment).