### PR TITLE
Fix version bump logic

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -28,8 +28,11 @@ if __name__ == '__main__':
     # Bump version part based on argument provided
     if args.part == 'major':
         major = str(int(major) + 1)
+        minor = 0
+        patch = 0
     if args.part == 'minor':
         minor = str(int(minor) + 1)
+        patch = 0
     if args.part == 'patch':
         patch = str(int(patch) + 1)
 


### PR DESCRIPTION
- Before if we do a major or minor version bump we don't reset the lower semantic versions. This fix resets the lower version back to zero when doing a higher version bump