### PR TITLE
Fix for Dockerfile smell DL3020

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ FROM python:3
 
 WORKDIR /app
 
-ADD requirements.txt /app/requirements.txt
+COPY requirements.txt /app/requirements.txt
 
 RUN pip install -r requirements.txt
 
-ADD asana /app/asana
-ADD examples /app/examples
-ADD tests /app/tests
-ADD setup.py /app/setup.py
-ADD README.md /app/README.md
+COPY asana /app/asana
+COPY examples /app/examples
+COPY tests /app/tests
+COPY setup.py /app/setup.py
+COPY README.md /app/README.md
 
 RUN find . -name '*.pyc' -delete
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3020 occurs if ADD is used to copy files and directories that do not require tar self-extraction. In such cases, it is recommended to use the COPY instruction.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the ADD instruction is replaced by an equivalent COPY instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance