### PR TITLE
Handle multiprocessing.pool.ThreadPool init on OS without shared memory for processes

### DIFF
--- a/codegen/templates/api_client.mustache
+++ b/codegen/templates/api_client.mustache
@@ -2,6 +2,7 @@
 {{>partial_header}}
 from __future__ import absolute_import
 
+import logging
 import datetime
 import json
 import mimetypes
@@ -63,7 +64,10 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        try:
+            self.pool = ThreadPool()
+        except OSError:
+            logging.warning('Looks like your system does not support ThreadPool but it will try without it if you do not use async requests')
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -83,8 +87,9 @@ class ApiClient(object):
         )
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if hasattr(self, "pool"):
+            self.pool.close()
+            self.pool.join()
 
     @property
     def user_agent(self):


### PR DESCRIPTION
AWS Lambda does not support multiprocessing.Queue or multiprocessing.Pool therefore the lib cannot init ThreadPool on Lambda.
This commit adds a possibility do not init ThreadPool if the OS does not support ThreadPool (shared memory for processes).
As far as async_req is disabled by default no need to change other functions.

More details: https://aws.amazon.com/blogs/compute/parallel-processing-in-python-with-aws-lambda/
