### PR TITLE
Disable attestation when publishing to Test PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -105,6 +105,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          attestation: false
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
   publish-to-github-releases:


### PR DESCRIPTION
Publishing is currently failing with errors like 
```
The error you're encountering is related to PyPI's recently implemented digital attestations feature. This error suggests that an attestation for the package "asana-5.0.12.tar.gz" has already been generated.
```

```
Attestation generation failure:
/github/workspace/dist/asana-5.0.13.tar.gz already has a publish attestation: /github/workspace/dist/asana-5.0.13.tar.gz.publish.attestation
You're seeing this because the action attempted to generated PEP 740
attestations for its inputs, but failed to do so.
```


@jv-asana pointed out that Test PyPI might be publishing the attestation to the same location that PyPI uses. Let's disable attestations when we upload to Test PyPI.