### PR TITLE
Upgrade swagger codegen version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ permissions:
   id-token: write
 
 env:
-  GENERATOR_VERSION: 3.0.54
+  GENERATOR_VERSION: 3.0.67
   GENERATOR_NAME: swagger-codegen-cli.jar
   JAR_ASANA: codegen/swagger/target/AsanaClientCodegen-swagger-codegen-1.0.0.jar
   ACTUAL_LANG: com.asana.codegen.PythonClientCodegenGenerator

--- a/codegen/swagger/pom.xml
+++ b/codegen/swagger/pom.xml
@@ -120,8 +120,8 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-codegen-version>3.0.44</swagger-codegen-version>
-        <swagger-codegen-generators-version>1.0.41</swagger-codegen-generators-version>
+        <swagger-codegen-version>3.0.67</swagger-codegen-version>
+        <swagger-codegen-generators-version>1.0.56</swagger-codegen-generators-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.1</junit-version>
         <build-helper-maven-plugin>3.0.0</build-helper-maven-plugin>


### PR DESCRIPTION
### TL;DR
Upgraded Swagger Codegen dependencies to latest versions

### What changed?
- Updated swagger-codegen-cli from 3.0.54 to 3.0.67
- Updated swagger-codegen from 3.0.44 to 3.0.67
- Updated swagger-codegen-generators from 1.0.41 to 1.0.56

### Why make this change?
Keeping dependencies up to date ensures we have the latest bug fixes, security patches, and improvements from the Swagger Codegen project. This helps maintain the quality and security of our generated code.