### PR TITLE
Add retry strategy

### DIFF
--- a/codegen/templates/README.mustache
+++ b/codegen/templates/README.mustache
@@ -484,7 +484,7 @@ By default, we retry failed requests (i.e., requests that receive any of the fol
 up to 5 times, using a backoff factor of 2, resulting in wait times of 1s, 2s, 4s, 8s, and 16s between attempts.
 For `429 (Too Many Requests)` responses, the `respect_retry_after_header` option is set to `True` by default
 (See [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html)), ensuring that retries adhere to the `Retry-After` header
-fron the [Asana API](https://developers.asana.com/docs/rate-limits).
+from the [Asana API](https://developers.asana.com/docs/rate-limits).
 
 
 NOTE: the retry strategy applies to `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PUT`, `TRACE` requests (See `allowed_methods` in [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html))

--- a/codegen/templates/README.mustache
+++ b/codegen/templates/README.mustache
@@ -491,9 +491,9 @@ NOTE: the retry strategy applies to `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PUT`, `
 
 ```
 self.retry_strategy = Retry(
-    total=5,  # Number of retries
-    backoff_factor=2,  # Exponential backoff factor (1s, 2s, 4s, etc.)
-    status_forcelist=[429, 500, 502, 503, 504],  # Retry only on these status codes
+    total=5, # Number of retries
+    backoff_factor=2, # Exponential backoff factor (1s, 2s, 4s, etc.)
+    status_forcelist=[429, 500, 502, 503, 504], # Retry only on these status codes
 )
 ```
 
@@ -510,7 +510,7 @@ from urllib3.util.retry import Retry
 configuration = asana.Configuration()
 configuration.retry_strategy = Retry(
     total=10, # Maximum number of retries
-    backoff_factor=4,  # Exponential backoff factor (1s, 2s, 4s, etc.)
+    backoff_factor=4, # Exponential backoff factor (1s, 2s, 4s, etc.)
 )
 ...
 ```

--- a/codegen/templates/README.mustache
+++ b/codegen/templates/README.mustache
@@ -482,12 +482,12 @@ api_client = {{{packageName}}}.ApiClient(configuration)
 
 By default, we retry failed requests (i.e., requests that receive any of the following response statuses: `429`, `500`, `502`, `503`, or `504`)
 up to 5 times, using a backoff factor of 2, resulting in wait times of 1s, 2s, 4s, 8s, and 16s between attempts.
-For 429 (Too Many Requests) responses, the `respect_retry_after_header` option is set to `True` by default
+For `429 (Too Many Requests)` responses, the `respect_retry_after_header` option is set to `True` by default
 (See [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html)), ensuring that retries adhere to the `Retry-After` header
 fron the [Asana API](https://developers.asana.com/docs/rate-limits).
 
 
-NOTE: the retry strategy applies to `DELETE, `GET`, `HEAD`, `OPTIONS`, `PUT`, `TRACE` requests (See `allowed_methods` in [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html))
+NOTE: the retry strategy applies to `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PUT`, `TRACE` requests (See `allowed_methods` in [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html))
 
 ```
 self.retry_strategy = Retry(
@@ -499,7 +499,7 @@ self.retry_strategy = Retry(
 
 ### Customize retry configuration/strategy
 
-To customize your retry strategy, you can override the default retry_strategy in your configuration.
+To customize your retry strategy, you can override the default `retry_strategy` in your configuration.
 For details on configurable options for Retry, refer to the documentation: [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html).
 
 #### Example - override default `retry_strategy`

--- a/codegen/templates/README.mustache
+++ b/codegen/templates/README.mustache
@@ -509,7 +509,7 @@ from urllib3.util.retry import Retry
 
 configuration = asana.Configuration()
 configuration.retry_strategy = Retry(
-    total=10 # Maximum number of retries
+    total=10, # Maximum number of retries
     backoff_factor=4,  # Exponential backoff factor (1s, 2s, 4s, etc.)
 )
 ...

--- a/codegen/templates/README.mustache
+++ b/codegen/templates/README.mustache
@@ -476,6 +476,45 @@ api_client = {{{packageName}}}.ApiClient(configuration)
 ...
 ```
 
+## Retries
+
+### Default configuration
+
+By default, we retry failed requests (i.e., requests that receive any of the following response statuses: `429`, `500`, `502`, `503`, or `504`)
+up to 5 times, using a backoff factor of 2, resulting in wait times of 1s, 2s, 4s, 8s, and 16s between attempts.
+For 429 (Too Many Requests) responses, the `respect_retry_after_header` option is set to `True` by default
+(See [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html)), ensuring that retries adhere to the `Retry-After` header
+fron the [Asana API](https://developers.asana.com/docs/rate-limits).
+
+
+NOTE: the retry strategy applies to `DELETE, `GET`, `HEAD`, `OPTIONS`, `PUT`, `TRACE` requests (See `allowed_methods` in [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html))
+
+```
+self.retry_strategy = Retry(
+    total=5,  # Number of retries
+    backoff_factor=2,  # Exponential backoff factor (1s, 2s, 4s, etc.)
+    status_forcelist=[429, 500, 502, 503, 504],  # Retry only on these status codes
+)
+```
+
+### Customize retry configuration/strategy
+
+To customize your retry strategy, you can override the default retry_strategy in your configuration.
+For details on configurable options for Retry, refer to the documentation: [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html).
+
+#### Example - override default `retry_strategy`
+```
+import asana
+from urllib3.util.retry import Retry
+
+configuration = asana.Configuration()
+configuration.retry_strategy = Retry(
+    total=10 # Maximum number of retries
+    backoff_factor=4,  # Exponential backoff factor (1s, 2s, 4s, etc.)
+)
+...
+```
+
 ## Documentation for Using the `call_api` method
 
 Use this to make HTTP calls when the endpoint does not exist in the current library version or has bugs

--- a/codegen/templates/configuration.mustache
+++ b/codegen/templates/configuration.mustache
@@ -106,9 +106,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
 
         # Retry Settings
         self.retry_strategy = Retry(
-            total=5,  # Number of retries
-            backoff_factor=2,  # Exponential backoff factor (1s, 2s, 4s, etc.)
-            status_forcelist=[429, 500, 502, 503, 504],  # Retry only on these status codes
+            total=5, # Number of retries
+            backoff_factor=2, # Exponential backoff factor (1s, 2s, 4s, etc.)
+            status_forcelist=[429, 500, 502, 503, 504], # Retry only on these status codes
         )
 
     @property

--- a/codegen/templates/configuration.mustache
+++ b/codegen/templates/configuration.mustache
@@ -9,6 +9,7 @@ import logging
 import multiprocessing
 import sys
 import urllib3
+from urllib3.util.retry import Retry
 
 import six
 from six.moves import http_client as httplib
@@ -102,6 +103,13 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
 
         # The default limit query parameter value for api endpoints that return multiple resources
         self.page_limit = 100
+
+        # Retry Settings
+        self.retry_strategy = Retry(
+            total=5,  # Number of retries
+            backoff_factor=2,  # Exponential backoff factor (1s, 2s, 4s, etc.)
+            status_forcelist=[429, 500, 502, 503, 504],  # Retry only on these status codes
+        )
 
     @property
     def logger_file(self):

--- a/codegen/templates/rest.mustache
+++ b/codegen/templates/rest.mustache
@@ -83,7 +83,7 @@ class RESTClientObject(object):
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
-                retries=configuration.retry_strategy,  # Attach the retry strategy here
+                retries=configuration.retry_strategy,
                 **addition_pool_args
             )
         else:
@@ -94,7 +94,7 @@ class RESTClientObject(object):
                 ca_certs=ca_certs,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
-                retries=configuration.retry_strategy,  # Attach the retry strategy here
+                retries=configuration.retry_strategy,
                 **addition_pool_args
             )
 

--- a/codegen/templates/rest.mustache
+++ b/codegen/templates/rest.mustache
@@ -83,6 +83,7 @@ class RESTClientObject(object):
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
+                retries=configuration.retry_strategy,  # Attach the retry strategy here
                 **addition_pool_args
             )
         else:
@@ -93,6 +94,7 @@ class RESTClientObject(object):
                 ca_certs=ca_certs,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
+                retries=configuration.retry_strategy,  # Attach the retry strategy here
                 **addition_pool_args
             )
 


### PR DESCRIPTION
Add retry strategy to python-asana client library

Implements automatic retry logic for failed API requests with exponential backoff. By default, requests are retried up to 5 times with increasing delays (1s, 2s, 4s, 8s, 16s). Retries occur on status codes 429, 500, 502, 503, and 504.

The retry configuration can be customized by overriding the `retry_strategy` in the configuration object. The implementation respects the `Retry-After` header for rate limit (429) responses.